### PR TITLE
fixed bugs with new version

### DIFF
--- a/ui/src/components/Header/Menu.tsx
+++ b/ui/src/components/Header/Menu.tsx
@@ -34,7 +34,7 @@ export const LongMenu = () => {
     const fetchImages = async () => {
       const images = (await ddClient.docker.listImages()) as DockerImage[];
 
-      const localstackImages = images.filter(image => image.RepoTags?.at(0).startsWith('localstack/'));
+      const localstackImages = images.filter(image => image.RepoTags?.at(0)?.startsWith('localstack/'));
       const imagesWithoutOrgName = localstackImages.map(image => removeRepoFromImage(image.RepoTags?.at(0)));
       setImages(imagesWithoutOrgName);
     };

--- a/ui/src/components/TabPanel/ControlledTabPanel.tsx
+++ b/ui/src/components/TabPanel/ControlledTabPanel.tsx
@@ -9,6 +9,8 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
     zIndex: 2,
     top: 64,
     backgroundColor: theme.palette.background.default,
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
   },
 }));
 

--- a/ui/src/services/util/containers.ts
+++ b/ui/src/services/util/containers.ts
@@ -11,7 +11,7 @@ export function removeRepoFromImage(repoTag: string) {
 }
 
 export function removeTagFromImage(image: DockerImage){
-  return image.RepoTags?.at(0).split(':').slice(0, -1).join(':');
+  return image.RepoTags?.at(0)?.split(':').slice(0, -1).join(':');
 }
 
 export const isALocalStackContainer = (container: DockerContainer) =>


### PR DESCRIPTION
After upgrading to docker desktop 4.20.1 something changed in the extensions API and now with dangling images instead of returning the `RepoTags` fields as `[<none>:<none>]` it returns simply `[]` causing an out-of-range error.
Also now the tabs are super stretched so I've added a bit of padding to make them look like before