### PR TITLE
fix(CLI): temporarly fix for starting the container

### DIFF
--- a/ui/src/components/Feedback/DownloadProgress/DownloadProgress.tsx
+++ b/ui/src/components/Feedback/DownloadProgress/DownloadProgress.tsx
@@ -3,6 +3,8 @@ import { useDDClient } from '../../../services';
 import { CircularProgressWithLabel } from './CircularProgressWithLabel';
 
 const SKIPPING_KEY = 'latest';
+const SKIPPING_ERROR = 'What\'s Next?';
+const SKIPPING_TAG_MESSAGE = 'Pulling from'; // message that get's sent if you pull a specific tag
 const END_KEYS = ['Digest', 'Status'];
 
 const statusValues = new Map([
@@ -35,13 +37,14 @@ export const DownloadProgress = ({ callback, imageName }: DownloadProgressProps)
     ddClient.docker.cli.exec('pull', [imageName], {
       stream: {
         onOutput(data): void {
-          if (data.stderr) {
+          if (data.stderr && data.stderr !== SKIPPING_ERROR) {
             ddClient.desktopUI.toast.error(data.stderr);
           }
 
           const [key, status] = data.stdout.split(':').map(item => item.trim());
 
-          if ([key, status].includes(SKIPPING_KEY)) { // prevent inserting in the map non related info
+          if ([key, status].includes(SKIPPING_KEY) ||
+            status.startsWith(SKIPPING_TAG_MESSAGE)) { // prevent inserting in the map non related info
             return;
           }
 

--- a/ui/src/components/Header/Controller.tsx
+++ b/ui/src/components/Header/Controller.tsx
@@ -91,7 +91,7 @@ export const Controller = (): ReactElement => {
     const isPro = runConfigs.find(config => config.name === runningConfig)
       .vars.some(item => item.variable === 'LOCALSTACK_API_KEY');
 
-    const haveCommunity = images.some(image => removeTagFromImage(image) === IMAGE);
+    const haveCommunity = images.some(image => image.RepoTags?.at(0) === IMAGE);
     if (!haveCommunity) {
       setDownloadProps({ open: true, image: IMAGE });
       return;
@@ -106,7 +106,6 @@ export const Controller = (): ReactElement => {
     }
 
     const args = await normalizeArguments();
-
     setIsStarting(true);
     ddClient.docker.cli.exec('run', args, {
       stream: {

--- a/ui/src/constants/common.ts
+++ b/ui/src/constants/common.ts
@@ -1,4 +1,4 @@
 export const DEFAULT_CONFIGURATION_ID='00000000-0000-0000-0000-000000000000';
 export const CORS_ALLOW_DEFAULT='http://localhost:3000';
-export const IMAGE = 'localstack/localstack';
+export const IMAGE = 'localstack/localstack:2.1.0';
 export const PRO_IMAGE = 'localstack/localstack-pro';

--- a/ui/src/constants/docker.ts
+++ b/ui/src/constants/docker.ts
@@ -1,3 +1,5 @@
+import { IMAGE } from './common';
+
 const COMMON_ARGS = [
   '--label',
   'cloud.localstack.spawner=true',
@@ -6,7 +8,7 @@ const COMMON_ARGS = [
   '--entrypoint=',
   '-v',
   '/var/run/docker.sock:/var/run/docker.sock',
-  'localstack/localstack:2.1.0',
+  IMAGE,
   'bin/localstack',
 ];
 

--- a/ui/src/constants/docker.ts
+++ b/ui/src/constants/docker.ts
@@ -6,7 +6,7 @@ const COMMON_ARGS = [
   '--entrypoint=',
   '-v',
   '/var/run/docker.sock:/var/run/docker.sock',
-  'localstack/localstack',
+  'localstack/localstack:2.1.0',
   'bin/localstack',
 ];
 


### PR DESCRIPTION
From LocalStack 2.2.0 onwards the CLI starts sending analytics and it tries to create/access files on the container which it can't so for now this PR fixes this issue downgrading the image for the spawner. 

Also adding some other small fixes to the download prompt that emerged when trying to download an image with a specific tag