### PR TITLE
fix(auth tokens) Added support for auth tokens

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE?=localstack/localstack-docker-desktop
-TAG?=0.5.1
+TAG?=0.5.2
 
 BUILDER=buildx-multi-arch
 

--- a/ui/src/components/Header/Controller.tsx
+++ b/ui/src/components/Header/Controller.tsx
@@ -101,12 +101,12 @@ export const Controller = (): ReactElement => {
     }
 
     const args = await normalizeArguments();
-    console.log('docker run ', args.join(' '));
+
     setIsStarting(true);
     ddClient.docker.cli.exec('run', args, {
       stream: {
         onOutput(data): void {
-          const shouldDisplayError = !EXCLUDED_ERROR_TOAST.some(item => data.stderr?.includes(item));
+          const shouldDisplayError = !EXCLUDED_ERROR_TOAST.some(item => data.stderr?.includes(item)) && data.stderr;
           if (shouldDisplayError) {
             ddClient.desktopUI.toast.error(data.stderr);
             setIsStarting(false);

--- a/ui/src/components/Views/Update/UpdateDialog.tsx
+++ b/ui/src/components/Views/Update/UpdateDialog.tsx
@@ -6,8 +6,8 @@ import {
   Typography,
 } from '@mui/material';
 import React, { ReactElement, useEffect, useState } from 'react';
-import { UPDATE_ARGS } from '../../../constants';
 import { useDDClient } from '../../../services';
+import { generateCLIArgs } from '../../../services/util/cli';
 
 type Props = {
   open: boolean,
@@ -20,7 +20,7 @@ export const UpdateDialog = ({ open, onClose }: Props): ReactElement => {
   const [isUpdating, setIsUpdating] = useState<boolean>(true);
 
   useEffect(() => {
-    const listener = ddClient.docker.cli.exec('run', UPDATE_ARGS, {
+    const listener = ddClient.docker.cli.exec('run', generateCLIArgs({ call: 'update' }), {
       stream: {
         onOutput(data): void {
           let resultStr = data.stdout

--- a/ui/src/components/Views/Update/UpdateDialog.tsx
+++ b/ui/src/components/Views/Update/UpdateDialog.tsx
@@ -28,6 +28,10 @@ export const UpdateDialog = ({ open, onClose }: Props): ReactElement => {
             .replaceAll('â', '✅')
             .replaceAll('â', '❌');
 
+          if (data.stdout.includes('Updating docker images')) {
+            resultStr = 'Updating Docker images';
+          }
+
           if (resultStr.endsWith('updated.')) {
             resultStr = resultStr.concat(' 🔼');
           }

--- a/ui/src/constants/common.ts
+++ b/ui/src/constants/common.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_CONFIGURATION_ID='00000000-0000-0000-0000-000000000000';
-export const CORS_ALLOW_DEFAULT='http://localhost:3000';
-export const IMAGE = 'localstack/localstack:latest';
+export const DEFAULT_CONFIGURATION_ID = '00000000-0000-0000-0000-000000000000';
+export const CORS_ALLOW_DEFAULT = 'http://localhost:3000';
+export const COMMUNITY_IMAGE = 'localstack/localstack';
 export const PRO_IMAGE = 'localstack/localstack-pro';

--- a/ui/src/constants/common.ts
+++ b/ui/src/constants/common.ts
@@ -1,4 +1,4 @@
 export const DEFAULT_CONFIGURATION_ID='00000000-0000-0000-0000-000000000000';
 export const CORS_ALLOW_DEFAULT='http://localhost:3000';
-export const IMAGE = 'localstack/localstack:2.1.0';
+export const IMAGE = 'localstack/localstack:latest';
 export const PRO_IMAGE = 'localstack/localstack-pro';

--- a/ui/src/constants/docker.ts
+++ b/ui/src/constants/docker.ts
@@ -1,30 +1,30 @@
-import { PRO_IMAGE } from './common';
+import { PRO_IMAGE, COMMUNITY_IMAGE } from './common';
 
-const COMMON_ARGS = [
-  '-i',
+export const COMMON_ARGS = [
+  '--label',
+  'cloud.localstack.spawner=true',
   '--rm',
+  '-i',
   '--entrypoint=',
   '-v',
   '/var/run/docker.sock:/var/run/docker.sock',
+];
+
+export const PRO_CLI = [
   PRO_IMAGE,
   './.venv/bin/python3',
   '-m',
   'localstack.cli.main',
 ];
 
+export const COMMUNITY_CLI = [COMMUNITY_IMAGE, 'bin/localstack'];
+
 export const START_ARGS = [
-  ...COMMON_ARGS,
   'start',
   '-d',
 ];
 
-export const STATUS_ARGS = [
-  ...COMMON_ARGS,
-  'status',
-];
-
 export const UPDATE_ARGS = [
-  ...COMMON_ARGS,
   'update',
   'docker-images',
 ];

--- a/ui/src/constants/docker.ts
+++ b/ui/src/constants/docker.ts
@@ -1,15 +1,15 @@
-import { IMAGE } from './common';
+import { PRO_IMAGE } from './common';
 
 const COMMON_ARGS = [
-  '--label',
-  'cloud.localstack.spawner=true',
-  '--rm',
   '-i',
+  '--rm',
   '--entrypoint=',
   '-v',
   '/var/run/docker.sock:/var/run/docker.sock',
-  IMAGE,
-  'bin/localstack',
+  PRO_IMAGE,
+  './.venv/bin/python3',
+  '-m',
+  'localstack.cli.main',
 ];
 
 export const START_ARGS = [
@@ -32,5 +32,5 @@ export const UPDATE_ARGS = [
 export const FLAGS = [
   '-e',
   // eslint-disable-next-line max-len
-  'DOCKER_FLAGS=\'--label com.docker.compose.project=localstack_localstack-docker-desktop-desktop-extension --label com.docker.desktop.extension=true --label com.docker.compose.project.config_files\'',
+  'DOCKER_FLAGS=--label com.docker.compose.project=localstack_localstack-docker-desktop-desktop-extension --label com.docker.desktop.extension=true --label com.docker.compose.project.config_files',
 ];

--- a/ui/src/services/util/cli.ts
+++ b/ui/src/services/util/cli.ts
@@ -1,0 +1,24 @@
+import { COMMON_ARGS, COMMUNITY_CLI, PRO_CLI, START_ARGS, UPDATE_ARGS } from '../../constants';
+
+export interface generateCLIArgsProps {
+  call: 'start' | 'update',
+  pro?: boolean,
+}
+
+export const generateCLIArgs = ({ call, pro = false }: generateCLIArgsProps): string[] => {
+  const callArgs = [...COMMON_ARGS];
+  if (pro) {
+    callArgs.push(...PRO_CLI);
+  } else {
+    callArgs.push(...COMMUNITY_CLI);
+  }
+
+  switch (call) {
+    case 'start': callArgs.push(...START_ARGS);
+      break;
+    default: callArgs.push(...UPDATE_ARGS);
+      break;
+  }
+  return callArgs;
+
+};

--- a/ui/src/services/util/format.ts
+++ b/ui/src/services/util/format.ts
@@ -21,7 +21,7 @@ const EXCLUDED_USER_WSL = ['[.]', '[..]', '\r'];
 
 export function getUsersFromBinaryWindows(res: string): string[] {
   return res.split('\n').filter(string => string.startsWith('[')) // get only directory rows (they are in form "[user1] [user2]" )
-    .map(elem =>elem.split(' ').filter(item => item.length > 0 && !EXCLUDED_USER_WSL.includes(item)))// get only dir names
+    .map(elem => elem.split(' ').filter(item => item.length > 0 && !EXCLUDED_USER_WSL.includes(item)))// get only dir names
     .reduce((accumulator, currentValue) => accumulator.concat(currentValue), []) // combine multiple lines into one
     .map(user => user.slice(1, -1)); // remove "[" and "]" from names
 }


### PR DESCRIPTION
## Problem

With localstack 2.2 we introduced the `machine.json` file which failed to be mounted because the cli attempted to mount it into /root (which does not have permission to). This is because the cli uses the $HOME env variable inside the host to determinate where it should mount these files. The problem is that it's used inside a container and the HOME for the container is pointing to /root so it tries to mount on root of the host 

## Solution
Overriding the HOME env variable with the correct one (already available because used for the mount point). This requires also a bit more tricks to it:
- the cli implementation of the auth token check is just inside the pro image so you need to start the pro container to spawn the cli
- the binaries of the cli are not present in the pro image so we invoke it directly via python inside venv
- the cli need the community image to work so we kind of force to have both on the host machine (that's why we download both of them)

As a side note, something changed with the parsing of additional flags, that's why I removed the `\'`