### PR TITLE
chore(Deps): Updated dependencies to remove vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.5.8] — 2026-01-27
+
+### Changed
+
+- Dependencies update and api-key text removal
+
+### Changed
+
+- Refactoring and dependencies update
+
 ## [0.5.7] — 2025-10-17
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.6-alpine AS builder
+FROM golang:1.25-alpine AS builder
 ENV CGO_ENABLED=0
 WORKDIR /backend
 COPY vm/go.* ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.25.6-alpine AS builder
 ENV CGO_ENABLED=0
 WORKDIR /backend
 COPY vm/go.* ./

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE?=localstack/localstack-docker-desktop
-TAG?=0.5.7
+TAG?=0.5.8
 
 BUILDER=buildx-multi-arch
 
@@ -8,7 +8,7 @@ NO_COLOR   = \033[m
 
 build-extension: ## Build service image to be deployed as a desktop extension
 	ls binaries/linux/localstack-* > /dev/null 2>&1 || ./downloadBinaries.sh
-	docker build --tag=$(IMAGE):$(TAG) . 
+	docker build --tag=$(IMAGE):$(TAG) .
 
 install-extension: build-extension ## Install the extension
 	docker extension install $(IMAGE):$(TAG)


### PR DESCRIPTION
Updated golang dependency to fix  CVE-2025-61729

Closes ENG-299

<img width="1019" height="335" alt="image" src="https://github.com/user-attachments/assets/3cd293e4-3480-4c7b-b3c7-ec943164eb40" />
