### PR TITLE
chore(versioning): Updated version to calendar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2026.3.0] — 2026-03-16
+
+### Changed
+
+- Dependencies update and introduction of calendar versioning format
+
 ## [0.5.8] — 2026-01-27
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE?=localstack/localstack-docker-desktop
-TAG?=0.5.8
+TAG?=2026.3.0
 
 BUILDER=buildx-multi-arch
 


### PR DESCRIPTION
Changed version switching from semver to calendar to be on pair with rest of LocalStack products

/cc @silv-io 