### PR TITLE
chore(security): Updated version for security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.5.9] — 2026-02-19
+
+### Changed
+
+- Security update
+
 ## [0.5.8] — 2026-01-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.5.9] — 2026-02-19
+## [0.5.9] — 2026-02-18
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE?=localstack/localstack-docker-desktop
-TAG?=0.5.8
+TAG?=0.5.9
 
 BUILDER=buildx-multi-arch
 


### PR DESCRIPTION
Re-built image to verify latest version of deps have no vulnerabilities


Closes ENG-431

<img width="1557" height="688" alt="image" src="https://github.com/user-attachments/assets/80a4b43a-1f46-4fb9-ad21-f2ed2f1f2e82" />


There are no actual changes, just the image needs to be re-built to download the latest version of alpine with the fix