### PR TITLE
fix(CVE-2026-22184): Update package on build step and update version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY ui /ui
 RUN npm run build
 
 FROM alpine
+RUN apk upgrade --no-cache
 LABEL org.opencontainers.image.title="LocalStack" \
   org.opencontainers.image.description="Extension of Localstack for Docker desktop" \
   org.opencontainers.image.vendor="LocalStack GmbH" \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE?=localstack/localstack-docker-desktop
-TAG?=2026.3.0
+TAG?=2026.4.0
 
 BUILDER=buildx-multi-arch
 


### PR DESCRIPTION
Current image is vulnerable to CVE-2026-22184. This PR updates the tag and deps in the alpine image to pull patched zlib version

Closes BEE-662

<img width="1078" height="292" alt="image" src="https://github.com/user-attachments/assets/9477871f-3418-4ae0-950e-4427f4aaa8ad" />
