### PR TITLE
fix(link): Fixed broken link to auth token page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE?=localstack/localstack-docker-desktop
-TAG?=2026.4.0
+TAG?=2026.4.1
 
 BUILDER=buildx-multi-arch
 

--- a/ui/src/components/Views/SystemStatus/StatusPage.tsx
+++ b/ui/src/components/Views/SystemStatus/StatusPage.tsx
@@ -108,7 +108,6 @@ export const StatusPage = (): ReactElement => {
           ))}
         </div>
       ) : (
-        // Your updated component
         <Alert severity="warning">
           Could not connect to a licensed LocalStack instance.{' '}
           <Link

--- a/ui/src/components/Views/SystemStatus/StatusPage.tsx
+++ b/ui/src/components/Views/SystemStatus/StatusPage.tsx
@@ -17,6 +17,7 @@ import {
   useLocalStackHealth,
   useLocalStack,
   capitalize,
+  useDDClient,
 } from '../../../services';
 import { HealthState } from '../../../types';
 
@@ -47,11 +48,13 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-const LICENSE_DOCS_URL = 'https://docs.localstack.cloud/aws/getting-started/auth-token/#configuring-your-auth-token';
+const LICENSE_DOCS_URL =
+  'https://docs.localstack.cloud/aws/getting-started/auth-token/#configuring-your-auth-token';
 
 export const StatusPage = (): ReactElement => {
   const { health, mutate } = useLocalStackHealth();
   const { data } = useLocalStack();
+  const { client: ddClient } = useDDClient();
 
   const isRunning = data && data.State === 'running';
 
@@ -105,6 +108,7 @@ export const StatusPage = (): ReactElement => {
           ))}
         </div>
       ) : (
+        // Your updated component
         <Alert severity="warning">
           Could not connect to a licensed LocalStack instance.{' '}
           <Link
@@ -113,6 +117,10 @@ export const StatusPage = (): ReactElement => {
             rel="noreferrer"
             color="inherit"
             underline="always"
+            onClick={(event) => {
+              event.preventDefault();
+              ddClient.host.openExternal(LICENSE_DOCS_URL);
+            }}
           >
             Learn how to configure your license
           </Link>


### PR DESCRIPTION
In the current implementation, clicking the "Learn how to configure your license" link inside the Alert component does not open the default system browser as expected. Instead, it attempts to navigate within the Docker Desktop Extension’s internal environment, which fails to load or opens in a constrained mini-window.
Now utilize the dockerDesktopApi (ddClient.host.openExternal) to explicitly command the host operating system to open the URL in the default browser.